### PR TITLE
feat: migrate gradle configure to latest version

### DIFF
--- a/.fvm/flutter_sdk
+++ b/.fvm/flutter_sdk
@@ -1,1 +1,1 @@
-/Users/thanhdt/fvm/versions/3.22.2
+/Users/dev/fvm/versions/3.24.5

--- a/.fvm/fvm_config.json
+++ b/.fvm/fvm_config.json
@@ -1,4 +1,4 @@
 {
-  "flutterSdkVersion": "3.22.2",
+  "flutterSdkVersion": "3.24.5",
   "flavors": {}
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,3 +1,9 @@
+plugins {
+    id "com.android.application"
+    id "kotlin-android"
+    id "dev.flutter.flutter-gradle-plugin"
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
@@ -6,10 +12,6 @@ if (localPropertiesFile.exists()) {
     }
 }
 
-def flutterRoot = localProperties.getProperty('flutter.sdk')
-if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
-}
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
 if (flutterVersionCode == null) {
@@ -21,12 +23,9 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'  
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 34
+    compileSdk 34
     ndkVersion flutter.ndkVersion
 
     compileOptions {
@@ -69,5 +68,4 @@ flutter {
 dependencies {
     implementation project(':app:androidauto')
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,15 +1,4 @@
-buildscript {
-    ext.kotlin_version = '1.9.22'
-    repositories {
-        google()
-        mavenCentral()
-    }
 
-    dependencies { 
-        classpath 'com.android.tools.build:gradle:7.2.0'  
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
 
 allprojects {
     repositories {

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,12 +1,26 @@
-include ':app'
+pluginManagement {
+    def flutterSdkPath = {
+        def properties = new Properties()
+        file("local.properties").withInputStream { properties.load(it) }
+        def flutterSdkPath = properties.getProperty("flutter.sdk")
+        assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
+        return flutterSdkPath
+    }()
 
-def localPropertiesFile = new File(rootProject.projectDir, "local.properties")
-def properties = new Properties()
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-assert localPropertiesFile.exists()
-localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
-def flutterSdkPath = properties.getProperty("flutter.sdk")
-assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "7.2.0" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.22" apply false
+}
+
+include ":app"
 include ':app:androidauto'


### PR DESCRIPTION
This pull request includes several updates to the Flutter SDK version and significant changes to the Android build configuration files. The most important changes include updating the Flutter SDK version, modifying the `build.gradle` and `settings.gradle` files to use plugins, and removing redundant configurations.

### Flutter SDK Version Update:
* Updated Flutter SDK version from `3.22.2` to `3.24.5` in `.fvm/flutter_sdk` and `.fvm/fvm_config.json`. [[1]](diffhunk://#diff-95473776c9cec35e2fe91b3aaacd066abf996cd609a47ac27ef3641bc7f0fb50L1-R1) [[2]](diffhunk://#diff-660fa2d6f4208e0ac78de89ac55484cc7ec6fad80e2626a529cb332bc011996cL2-R2)

### Android Build Configuration Changes:
* Added plugin configurations for `com.android.application`, `kotlin-android`, and `dev.flutter.flutter-gradle-plugin` in `android/app/build.gradle`.
* Removed redundant Flutter SDK location check and plugin applications from `android/app/build.gradle`. [[1]](diffhunk://#diff-9526ccfd1d1813ed49c39f8c54dbeb512607376a007d824b905bc8b4e4d202d9L9-L12) [[2]](diffhunk://#diff-9526ccfd1d1813ed49c39f8c54dbeb512607376a007d824b905bc8b4e4d202d9L24-R28)
* Removed unused Kotlin standard library dependency from `android/app/build.gradle`.
* Removed the `buildscript` block and its dependencies from `android/build.gradle`.
* Refactored `android/settings.gradle` to use `pluginManagement` and include necessary plugins and repositories.